### PR TITLE
Version1.0 development return blur areas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,24 @@
       <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-vision</artifactId>
+      <version>1.70.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/google/sps/servlets/GetBlurAreasServlet.java
+++ b/src/main/java/com/google/sps/servlets/GetBlurAreasServlet.java
@@ -69,6 +69,8 @@ public class GetBlurAreasServlet extends HttpServlet {
 
     // User uploaded an unsupported type of file, so render an error message.
     if (!isImageSupported(blobKey)) {
+      deleteFile(blobKey);
+
       response.setContentType("text/html;");
       response.getWriter().println("Image extension not supported.");
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -79,10 +81,7 @@ public class GetBlurAreasServlet extends HttpServlet {
     byte[] imageBytes = getBlobBytes(blobKey);
 
     ArrayList<List<Point>> blurAreas = getBlurAreas(imageBytes);
-
-    // Delete the image from the blobstore.
-    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-    blobstoreService.delete(blobKey);
+    deleteFile(blobKey);
 
     // Convert the rectangles to JSON.
     Gson gson = new Gson();
@@ -202,5 +201,11 @@ public class GetBlurAreasServlet extends HttpServlet {
   private Boolean isImageSupported(BlobKey blobKey) {
     BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
     return supportedTypes.contains(blobInfo.getContentType());
+  }
+
+  /** Deletes a file from the blobstore */
+  private void deleteFile(BlobKey blobKey) {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    blobstoreService.delete(blobKey);
   }
 }


### PR DESCRIPTION
Create the '/get-blur-areas' servlet. 
After users upload a photo to the blobstore system, the servlet is called with a BlobKey parameter containing the location of the photo in the blobstore.
Responds with rectangles describing which areas from the photo should be blurred.