### PR TITLE
Respond with empty list if no blur option selected

### DIFF
--- a/src/main/java/com/google/sps/servlets/GetBlurAreasServlet.java
+++ b/src/main/java/com/google/sps/servlets/GetBlurAreasServlet.java
@@ -115,7 +115,14 @@ public class GetBlurAreasServlet extends HttpServlet {
       partsToBlurMask |= LOGO_BLUR_MASK;
     }
 
-    ArrayList<List<Point>> blurAreas = getBlurAreas(imageBytes, partsToBlurMask);
+    ArrayList<List<Point>> blurAreas;
+    // If the user selected at least one part to blur, call getBlurAreas. Else respond with an
+    // empty list.
+    if (partsToBlurMask != 0) {
+      blurAreas = getBlurAreas(imageBytes, partsToBlurMask);
+    } else {
+      blurAreas = new ArrayList<List<Point>>();
+    }
     deleteFile(blobKey);
 
     // Convert the rectangles to JSON.


### PR DESCRIPTION
Bugfix: If user selects nothing to blur, just return an empty list without calling the getBlurAreas function. Calling Cloud Vision API with no feature resulted in an internal server error.